### PR TITLE
Replaced outdated module name in tests (molenc to molbart)

### DIFF
--- a/evaluate.sh
+++ b/evaluate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-python -m molenc.evaluate \
+python -m molbart.evaluate \
  --data_path ../data/pande_dataset.pickle \
  --tokeniser_path ../tokenisers/chembl_concat.pickle \
  --model_path tb_logs/forward_prediction/version_3/checkpoints/epoch\=92.ckpt \

--- a/fine_tune.sh
+++ b/fine_tune.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-python -m molenc.fine_tune \
+python -m molbart.fine_tune \
  --dataset uspto_mit \
  --data_path ../data/uspto_mixed.pickle \
  --tokeniser_path ../tokenisers/mol_opt_tokeniser.pickle \

--- a/hparam_tune.sh
+++ b/hparam_tune.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-python -m molenc.tune_hparams \
+python -m molbart.tune_hparams \
  --data_path ../data/pande_dataset.pickle \
  --tokeniser_path ../tokenisers/chembl_concat.pickle \
  --model_path saved_models/transformer/version_3/checkpoints/epoch\=9.ckpt \

--- a/molbart/build_tokeniser.py
+++ b/molbart/build_tokeniser.py
@@ -3,13 +3,13 @@ import argparse
 from pathlib import Path
 from rdkit import Chem
 
-from molenc.dataset import (
+from molbart.dataset import (
     Chembl, 
     MoleculeDataset,
     ConcatMoleculeDataset,
     MolOptDataset,
 )
-from molenc.tokenise import MolEncTokeniser
+from molbart.tokenise import MolEncTokeniser
 
 
 MOL_OPT_TOKENS_PATH = "mol_opt_tokens.txt"

--- a/molbart/dataset.py
+++ b/molbart/dataset.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 from torch.utils.data import Dataset, DataLoader, Sampler, RandomSampler, SequentialSampler
 from pysmilesutils.augment import MolRandomizer
 
-from molenc.tokenise import MolEncTokeniser
+from molbart.tokenise import MolEncTokeniser
 
 
 # --------------------------------------------------------------------------------------------------------

--- a/molbart/evaluate.py
+++ b/molbart/evaluate.py
@@ -5,9 +5,9 @@ from pathlib import Path
 from pytorch_lightning import Trainer
 from pytorch_lightning.loggers import TensorBoardLogger
 
-from molenc.models import TransformerModel, ReactionPredModel
-from molenc.dataset import Uspto50, FineTuneReactionDataModule
-from molenc.decode import DecodeSampler
+from molbart.models import TransformerModel, ReactionPredModel
+from molbart.dataset import Uspto50, FineTuneReactionDataModule
+from molbart.decode import DecodeSampler
 
 
 DEFAULT_BATCH_SIZE = 32

--- a/molbart/fine_tune.py
+++ b/molbart/fine_tune.py
@@ -7,9 +7,9 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint, Callback
 
-from molenc.models import BARTModel, ReactionPredModel
-from molenc.dataset import Uspto50, UsptoMit, FineTuneReactionDataModule
-from molenc.decode import DecodeSampler
+from molbart.models import BARTModel, ReactionPredModel
+from molbart.dataset import Uspto50, UsptoMit, FineTuneReactionDataModule
+from molbart.decode import DecodeSampler
 
 
 DEFAULT_BATCH_SIZE = 32

--- a/molbart/train.py
+++ b/molbart/train.py
@@ -6,16 +6,16 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint
 
-from molenc.dataset import (
+from molbart.dataset import (
     Uspto50, 
     Chembl, 
     MoleculeDataset,
     ConcatMoleculeDataset,
     MoleculeDataModule
 )
-from molenc.models import BARTModel
-from molenc.tokenise import MolEncTokeniser
-from molenc.decode import DecodeSampler
+from molbart.models import BARTModel
+from molbart.tokenise import MolEncTokeniser
+from molbart.decode import DecodeSampler
 
 
 DEFAULT_BATCH_SIZE = 32

--- a/molbart/tune_hparams.py
+++ b/molbart/tune_hparams.py
@@ -9,9 +9,9 @@ from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint, Callback
 from functools import partial
 
-from molenc.models import BARTModel, ReactionPredModel
-from molenc.dataset import Uspto50, FineTuneReactionDataModule
-from molenc.decode import DecodeSampler
+from molbart.models import BARTModel, ReactionPredModel
+from molbart.dataset import Uspto50, FineTuneReactionDataModule
+from molbart.decode import DecodeSampler
 
 
 DEFAULT_TIMEOUT_HOURS = 28 * 24

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="molenc",
-    packages=["molenc"]
+    name="molbart",
+    packages=["molbart"]
 )

--- a/test/decode_test.py
+++ b/test/decode_test.py
@@ -1,7 +1,7 @@
 import torch
 from unittest.mock import patch, MagicMock, call
 
-from molenc.decode import DecodeSampler
+from molbart.decode import DecodeSampler
 
 
 def test_transpose_list():
@@ -26,7 +26,7 @@ def test_sort_beams():
     assert exp_log_lhs == sorted_log_lhs
 
 
-@patch("molenc.tokenise.MolEncTokeniser")
+@patch("molbart.tokenise.MolEncTokeniser")
 def test_greedy_calls_decode(tokeniser):
     max_seq_len = 3
     batch_size = 4
@@ -45,7 +45,7 @@ def test_greedy_calls_decode(tokeniser):
     assert len(decode_fn.call_args_list) == expected_calls
 
 
-@patch("molenc.tokenise.MolEncTokeniser")
+@patch("molbart.tokenise.MolEncTokeniser")
 def test_greedy_chooses_max(tokeniser):
     max_seq_len = 3
     batch_size = 1
@@ -79,7 +79,7 @@ def test_greedy_chooses_max(tokeniser):
     tokeniser.convert_ids_to_tokens.assert_called_once_with(exp_tokens)
 
 
-@patch("molenc.tokenise.MolEncTokeniser")
+@patch("molbart.tokenise.MolEncTokeniser")
 def test_greedy_calls_decode(tokeniser):
     max_seq_len = 3
     batch_size = 4
@@ -101,7 +101,7 @@ def test_greedy_calls_decode(tokeniser):
     assert len(decode_fn.call_args_list) == expected_calls
 
 
-@patch("molenc.tokenise.MolEncTokeniser")
+@patch("molbart.tokenise.MolEncTokeniser")
 def test_beam_chooses_correct_tokens(tokeniser):
     max_seq_len = 4
     batch_size = 1

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -2,9 +2,9 @@ import pytest
 import torch
 import random
 
-from molenc.models import BARTModel
-from molenc.tokenise import MolEncTokeniser
-from molenc.decode import DecodeSampler
+from molbart.models import BARTModel
+from molbart.tokenise import MolEncTokeniser
+from molbart.decode import DecodeSampler
 
 
 # Use dummy SMILES strings

--- a/test/tokeniser_test.py
+++ b/test/tokeniser_test.py
@@ -1,7 +1,7 @@
 import torch
 import random
 
-from molenc.tokenise import MolEncTokeniser
+from molbart.tokenise import MolEncTokeniser
 
 
 # Use dummy SMILES strings

--- a/train.sh
+++ b/train.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-python -m molenc.train 
+python -m molbart.train 
  --data_path ../data/chembl_27.pickle \
  --tokeniser_path ../tokenisers/mol_opt_tokeniser.pickle \
  --model_type bart \


### PR DESCRIPTION
There was an error in the tests caused by an outdated module name being used. Fix was done by running the following command:


```
find ./ -type f -exec sed -i 's/molenc/molbart/g' {} \;
```